### PR TITLE
fix using `fmt` to printf.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -156,7 +156,7 @@ func (engine *Engine) CheckMem() {
 	if !engine.initOptions.UseStorage {
 		log.Println("Check virtualMemory...")
 		vmem, _ := mem.VirtualMemory()
-		fmt.Printf("Total: %v, Free:%v, UsedPercent:%f%%\n", vmem.Total, vmem.Free, vmem.UsedPercent)
+		log.Printf("Total: %v, Free:%v, UsedPercent:%f%%\n", vmem.Total, vmem.Free, vmem.UsedPercent)
 		useMem := fmt.Sprintf("%.2f", vmem.UsedPercent)
 		if useMem == "99.99" {
 			engine.initOptions.UseStorage = true


### PR DESCRIPTION
Using `log` to printf instead of `fmt`

The pull request will be closed without any reasons if it does not satisfy any of following requirements:

1. Make sure you are targeting the `master` branch, pull requests on release branches are only allowed for bug fixes.
2. Please read contributing guidelines: [CONTRIBUTING](https://github.com/go-ego/riot/blob/master/CONTRIBUTING.md)
3. Describe what your pull request does and which issue you're targeting (if any and Please use English)
4. ... if it is not related to any particular issues, explain why we should not reject your pull request.
5. The Commits must use English, must be test and No useless submissions.
    
## Description

Just a simple issue, the `engine.go` using `fmt.Printf` to print info, that comes console while using self project, using `log.Printf` instead, in order to hook log message by self logger if needed.